### PR TITLE
Added server and client proxies so that the mod doesn't crash on dedicated server

### DIFF
--- a/src/main/java/com/fireball1725/defaultworldgenerator/DefaultWorldGenerator.java
+++ b/src/main/java/com/fireball1725/defaultworldgenerator/DefaultWorldGenerator.java
@@ -1,41 +1,26 @@
 package com.fireball1725.defaultworldgenerator;
-
-import com.fireball1725.defaultworldgenerator.config.ConfigGeneralSettings;
-import com.fireball1725.defaultworldgenerator.config.ConfigurationFile;
-import com.fireball1725.defaultworldgenerator.events.GuiEvents;
-import com.fireball1725.defaultworldgenerator.lib.Log;
 import com.fireball1725.defaultworldgenerator.lib.Reference;
+import com.fireball1725.defaultworldgenerator.proxy.Proxy;
 import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import net.minecraft.world.WorldType;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.config.Configuration;
 
 @Mod(modid = Reference.MOD_ID, name = Reference.MOD_NAME, version = Reference.VERSION_BUILD)
 public class DefaultWorldGenerator {
     @Mod.Instance
     public static DefaultWorldGenerator instance;
 
-    public static Configuration configuration;
+    @SidedProxy(serverSide="com.fireball1725.defaultworldgenerator.proxy.ProxyServer", clientSide = "com.fireball1725.defaultworldgenerator.proxy.ProxyClient")
+    public static Proxy proxy;
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        configuration = ConfigurationFile.init(event.getSuggestedConfigurationFile());
-
-        MinecraftForge.EVENT_BUS.register(new GuiEvents());
+        proxy.preInit(event);
     }
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
-        if (ConfigGeneralSettings.generalShowDebugWorldGenerators) {
-            Log.info("=======================[ World Generators ]=======================");
-            for (int i = 0; i < WorldType.worldTypes.length; i++) {
-                if (WorldType.worldTypes[i] != null && WorldType.worldTypes[i].getCanBeCreated()) {
-                    Log.info("Name: " + WorldType.worldTypes[i].getWorldTypeName());
-                }
-            }
-            Log.info("==================================================================");
-        }
+        proxy.postInit(event);
     }
 }

--- a/src/main/java/com/fireball1725/defaultworldgenerator/proxy/Proxy.java
+++ b/src/main/java/com/fireball1725/defaultworldgenerator/proxy/Proxy.java
@@ -1,0 +1,12 @@
+package com.fireball1725.defaultworldgenerator.proxy;
+
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+
+public abstract class Proxy
+{
+	public abstract void preInit(FMLPreInitializationEvent event);
+	public abstract void init(FMLInitializationEvent event);
+	public abstract void postInit(FMLPostInitializationEvent event);
+}

--- a/src/main/java/com/fireball1725/defaultworldgenerator/proxy/ProxyClient.java
+++ b/src/main/java/com/fireball1725/defaultworldgenerator/proxy/ProxyClient.java
@@ -1,0 +1,41 @@
+package com.fireball1725.defaultworldgenerator.proxy;
+import com.fireball1725.defaultworldgenerator.config.ConfigGeneralSettings;
+import com.fireball1725.defaultworldgenerator.config.ConfigurationFile;
+import com.fireball1725.defaultworldgenerator.events.GuiEvents;
+import com.fireball1725.defaultworldgenerator.lib.Log;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import net.minecraft.world.WorldType;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.Configuration;
+
+public class ProxyClient extends Proxy
+{
+	public static Configuration configuration;
+
+	@Override
+	public void preInit(FMLPreInitializationEvent event) {
+		configuration = ConfigurationFile.init(event.getSuggestedConfigurationFile());
+		MinecraftForge.EVENT_BUS.register(new GuiEvents());
+	}
+
+	@Override
+	public void init(FMLInitializationEvent event) {
+	}
+
+	@Override
+	public void postInit(FMLPostInitializationEvent event) {
+		if (ConfigGeneralSettings.generalShowDebugWorldGenerators) {
+			Log.info("=======================[ World Generators ]=======================");
+			for (int i = 0; i < WorldType.worldTypes.length; i++) {
+				if (WorldType.worldTypes[i] != null && WorldType.worldTypes[i].getCanBeCreated()) {
+					Log.info("Name: " + WorldType.worldTypes[i].getWorldTypeName());
+				}
+			}
+			Log.info("==================================================================");
+		}
+	}
+}
+
+

--- a/src/main/java/com/fireball1725/defaultworldgenerator/proxy/ProxyServer.java
+++ b/src/main/java/com/fireball1725/defaultworldgenerator/proxy/ProxyServer.java
@@ -1,0 +1,20 @@
+package com.fireball1725.defaultworldgenerator.proxy;
+
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+
+public class ProxyServer extends Proxy
+{
+	@Override
+	public void preInit(FMLPreInitializationEvent event) {
+	}
+
+	@Override
+	public void init(FMLInitializationEvent event) {
+	}
+
+	@Override
+	public void postInit(FMLPostInitializationEvent event) {
+	}
+}


### PR DESCRIPTION
I've just used your mod in a modpack I've put together on the Curse Voice client, and understand that this is a client only mod. However, when I put packs together, I always ensure that the pack will work both on a client and dedicated server. It's not possible to maintain server versions of packs on the Curse Voice Client, so I only get a single pack that has to work on both server and client.

I've forked your mod, and have added a sided proxy, such that if the mod is installed on a dedicated server, no initialisation is performed, and the mod isn't loaded, however on a client, the mod will be loaded as normal. I've not made any other changes, so functionality shouldn't have changed.

If you're happy with the changes I've made, I'd be delighted if you'd merge these changes into your code base, then when the mod is next updated, players that use my pack (and other packs that use your mod), will have a nice easy method of getting a dedicated server up and running without having to deal with exceptions that they probably won't understand.
